### PR TITLE
Fixed a typo in help message

### DIFF
--- a/model_angelo/apps/build.py
+++ b/model_angelo/apps/build.py
@@ -64,7 +64,7 @@ def add_args(parser):
         "-rf",
         type=str,
         required=False,
-        help="The path to the protein sequence file",
+        help="The path to the RNA sequence file",
     )
     parser.add_argument(
         "--dna-fasta",
@@ -72,7 +72,7 @@ def add_args(parser):
         "-df",
         required=False,
         type=str,
-        help="The path to the protein sequence file",
+        help="The path to the DNA sequence file",
     )
     main_args.add_argument(
         "--output-dir",


### PR DESCRIPTION
Hello,

I noticed that `model_angelo build -h` has some typos. All fasta file options are said to be for the protein sequence. I fixed this confusion. There is no change to the code, only to help strings.

I hope this helps.
