### PR TITLE
Output cleaned fasta files to output folder instead of input folder

### DIFF
--- a/model_angelo/apps/build.py
+++ b/model_angelo/apps/build.py
@@ -180,7 +180,7 @@ def main(parsed_args):
 
         # Try to open FASTA       --------------------------------------------------------------------------------------
         from model_angelo.utils.fasta_utils import read_fasta
-        new_protein_fasta_path = write_fasta_only_aa(parsed_args.protein_fasta)
+        new_protein_fasta_path = write_fasta_only_aa(parsed_args.protein_fasta, parsed_args.output_dir)
         try:
             read_fasta(new_protein_fasta_path)
         except Exception as e:

--- a/model_angelo/apps/hmm_search.py
+++ b/model_angelo/apps/hmm_search.py
@@ -162,7 +162,7 @@ def main(parsed_args):
             digital_sequences = sf.read_block()
     except ValueError:
         # Write without gaps and try again
-        new_fasta_path = write_fasta_no_gaps(parsed_args.fasta_path)
+        new_fasta_path = write_fasta_no_gaps(parsed_args.fasta_path, parsed_args.output_dir)
         with pyhmmer.easel.SequenceFile(
             new_fasta_path, 
             alphabet=alphabet,

--- a/model_angelo/utils/fasta_utils.py
+++ b/model_angelo/utils/fasta_utils.py
@@ -113,19 +113,23 @@ def split_fasta_file_into_chains(fasta_path, out_dir):
             i += 1
 
 
-def write_fasta_no_gaps(fasta_input_path: str):
-    new_file_name = os.path.splitext(fasta_input_path)[0] + "_no_gaps.fasta"
-    with open(new_file_name, "w") as f:
+def write_fasta_no_gaps(fasta_input_path: str, output_dir: str):
+    file_name = os.path.basename(fasta_input_path)
+    new_file_name = os.path.splitext(file_name)[0] + "_no_gaps.fasta"
+    new_file_path = os.path.join(output_dir, new_file_name)
+    with open(new_file_path, "w") as f:
         for record in SeqIO.parse(fasta_input_path, "fasta"):
             f.write(f">{record.description}\n")
             f.write(remove_gaps(str(record.seq)) + "\n")
-    return new_file_name
+    return new_file_path
 
 
-def write_fasta_only_aa(fasta_input_path: str):
-    new_file_name = os.path.splitext(fasta_input_path)[0] + "_only_aa.fasta"
+def write_fasta_only_aa(fasta_input_path: str, output_dir: str):
+    file_name = os.path.basename(fasta_input_path)
+    new_file_name = os.path.splitext(file_name)[0] + "_only_aa.fasta"
+    new_file_path = os.path.join(output_dir, new_file_name)
     removed_residues = False
-    with open(new_file_name, "w") as f:
+    with open(new_file_path, "w") as f:
         for record in SeqIO.parse(fasta_input_path, "fasta"):
             old_seq = str(record.seq)
             new_seq = remove_non_residue(old_seq)
@@ -134,13 +138,13 @@ def write_fasta_only_aa(fasta_input_path: str):
                 f.write(f">{record.description}\n")
                 f.write(new_seq + "\n")
     if not removed_residues:
-        os.remove(new_file_name)
-        new_file_name = fasta_input_path
+        os.remove(new_file_path)
+        new_file_path = fasta_input_path
     else:
         warnings.warn(
             f"File {fasta_input_path} contains non-protein residues. These were removed."
         )
-    return new_file_name
+    return new_file_path
 
 
 def parse_hhr(hhr_file_path, max_num_seq=np.inf, align_sequence=False):


### PR DESCRIPTION
Hi Kiarash!

Since 1.0.8, there are additional checks/rewrites for .fasta files (`write_fasta_only_aa` and `write_fasta_no_gaps`). Both of those checks output the reformatted file next to the input file. I propose the reformatted files are written to the output folder instead.

While this is a very minor change, that would really help in our use case, where we enforce that inputs and input folders are always read-only. Thanks!