### PR TITLE
Repair compatibility with old PyTorch (RELION issue #1322).

### DIFF
--- a/model_angelo/gnn/inference.py
+++ b/model_angelo/gnn/inference.py
@@ -40,10 +40,10 @@ from model_angelo.utils.torch_utils import (
 from model_angelo.models.multi_gpu_wrapper import MultiGPUWrapper
 
 # Check if new API is available (PyTorch 2.9+)
-if hasattr(torch.backends.cuda.matmul, "fp32_precision"):
+try:
     torch.backends.cuda.matmul.fp32_precision = "tf32"
     torch.backends.cudnn.conv.fp32_precision = "tf32"
-else:
+except:
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
 


### PR DESCRIPTION
`hasattr` raises an Exception instead of returning False in this context.

Please see https://github.com/3dem/relion/issues/1322#issuecomment-4167294391.