### PR TITLE
Fix nucleotide postprocessing alignment

### DIFF
--- a/model_angelo/__init__.py
+++ b/model_angelo/__init__.py
@@ -5,4 +5,4 @@ ModelAngelo - Automated Cryo-EM model building toolkit
 """
 
 
-__version__ = "1.0.16"
+__version__ = "1.0.17"

--- a/model_angelo/utils/hmm_sequence_align.py
+++ b/model_angelo/utils/hmm_sequence_align.py
@@ -30,6 +30,32 @@ HMMAlignment = namedtuple(
     ],
 )
 
+RNA_RESTYPE_INDICES = np.array(
+    [
+        restype_3_to_index["A"],
+        restype_3_to_index["C"],
+        restype_3_to_index["G"],
+        restype_3_to_index["U"],
+    ],
+    dtype=np.int64,
+)
+DNA_RESTYPE_INDICES = np.array(
+    [
+        restype_3_to_index["DA"],
+        restype_3_to_index["DC"],
+        restype_3_to_index["DG"],
+        restype_3_to_index["DT"],
+    ],
+    dtype=np.int64,
+)
+
+
+def nucleotide_argmax_from_logits(
+    aa_logits: np.ndarray, nucleotide_indices: np.ndarray
+) -> np.ndarray:
+    local_argmax = np.argmax(aa_logits[..., nucleotide_indices], axis=-1)
+    return nucleotide_indices[local_argmax]
+
 
 def get_hmm_alignment(
     aa_logits: np.ndarray,
@@ -97,7 +123,7 @@ def get_hmm_alignment(
                 np.array([len(remove_non_residue(x)) for x in dna_processed_msas])
             )
         if has_rna_seq and has_dna_seq:
-            if rna_seq_val <= dna_seq_val:
+            if rna_seq_val >= dna_seq_val:
                 match_type = "RNA"
             else:
                 match_type = "DNA"
@@ -119,7 +145,9 @@ def get_hmm_alignment(
             )
             index_dict = alphabet_to_index["RNA"]
             seq_idx = rna_seq_idx + len(digital_prot_sequences)
-            original_pred_seq = np.full(len(aa_logits), fill_value=restype_3_to_index["N"], dtype=np.int64)
+            original_pred_seq = nucleotide_argmax_from_logits(
+                aa_logits, RNA_RESTYPE_INDICES
+            )
         elif match_type == "DNA":
             original_seq = None if not do_pp else raw_dna_sequences[dna_seq_idx]
             msa_index_corr = get_msa_index_correspondence(
@@ -129,7 +157,9 @@ def get_hmm_alignment(
             seq_idx = (
                 dna_seq_idx + len(digital_prot_sequences) + len(digital_rna_sequences)
             )
-            original_pred_seq = np.full(len(aa_logits), fill_value=restype_3_to_index["DN"], dtype=np.int64)
+            original_pred_seq = nucleotide_argmax_from_logits(
+                aa_logits, DNA_RESTYPE_INDICES
+            )
         match_sequence = msa_index_corr.sequence
 
     msa_sequence = np.array(


### PR DESCRIPTION
## Summary

- Fix RNA-vs-DNA nucleotide HMM selection to choose the molecule type with the larger aligned length.
- Fill nucleotide HMM alignment gaps from the network's local RNA/DNA base logits instead of defaulting gaps to unknown `N`/`DN`.
- Bump the package version from `1.0.16` to `1.0.17`.

## Why

The nucleotide postprocessing path compares the best RNA and DNA HMM alignments after optionally collapsing nucleotides to purine/pyrimidine states. The previous RNA/DNA branch chose RNA when `rna_aligned_length <= dna_aligned_length`, which inverted the intended comparison and caused DNA-supported chains to be labeled as RNA in many cases.

The gap fill behavior also had a systematic sequence-error mode. When the HMM alignment leaves a nucleotide position as a gap, the code filled it with `N` or `DN`. Those unknown residues are later converted to `C`/`DC` for writing, which turns alignment gaps into deterministic cytosine calls. This PR instead uses the network's local base logits within the selected molecule type alphabet, preserving model signal for those positions.

## Benchmark

I validated these changes with a replay benchmark over cached ModelAngelo postprocessing inputs from 25 RCSB cryo-EM cases. The benchmark re-runs only the postprocessing stage from saved GNN outputs, writes fresh CIFs, and evaluates the resulting pruned structures against reference models with a fixed evaluator seed. The set was split before tuning into 18 tuning cases and 7 locked cases, and each candidate was compared pairwise against the same cached baseline outputs so that changes isolate postprocessing behavior rather than GNN inference variance.

Combined validated effect of the two changes on all 25 cases, relative to the original postprocessing baseline:

- Nucleotide sequence match: **+37.75 percentage points mean**, **+44.78 pp median**.
- Nucleotide sequence coverage: **+27.94 pp mean**, **+30.57 pp median**.
- Nucleotide recall / precision were essentially unchanged: recall **+0.08 pp mean**, precision **+0.01 pp mean**.
- Nucleotide lDDT was essentially unchanged: **-0.09 pp mean**.
- Both-mode sequence match improved **+2.25 pp mean**.

Ablation results:

- RNA/DNA aligned-length sign fix was the large win: tuning nucleotide sequence match improved **+36.78 pp mean**; locked nucleotide sequence match improved **+34.59 pp mean**.
- Network-logit gap fill was a smaller robust win on top of the sign fix: full-set nucleotide sequence match improved an additional **+1.58 pp mean** and sequence coverage **+1.10 pp mean**, with geometry metrics unchanged.

Other nearby postprocessing ideas were tested and rejected or left out of this PR because they were neutral, mixed, artifact-only, or tuning-sensitive. This PR intentionally contains only the validated behavior changes plus the version bump.

## Validation

- `python3 -m py_compile model_angelo/utils/hmm_sequence_align.py model_angelo/__init__.py`
- `git diff --check`
